### PR TITLE
chore(package): license

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "GPL-3.0",
   "devDependencies": {
     "@balancer-labs/v2-deployments": "^2.3.0",
     "@etherpacks/dpack": "^0.0.24",


### PR DESCRIPTION
WETH pack states license is GPL-3.0, ISC is default of `npm init`